### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server that automatically generates complete favicon sets from PNG images or URLs. This server creates a comprehensive set of favicon files including various sizes, Apple touch icons, and a manifest.json file.
 
+<a href="https://glama.ai/mcp/servers/@dh1011/auto-favicon-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dh1011/auto-favicon-mcp/badge" alt="Auto Favicon Server MCP server" />
+</a>
+
 ## Features
 
 - **PNG to Favicon**: Generate favicon sets from local PNG files


### PR DESCRIPTION
This PR adds a badge for the [Auto Favicon MCP Server](https://glama.ai/mcp/servers/@dh1011/auto-favicon-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@dh1011/auto-favicon-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dh1011/auto-favicon-mcp/badge" alt="Auto Favicon Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.